### PR TITLE
sequential workflows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { RacePromptControlModule } from "@/controls/modules/RacePromptControlMod
 import { ImprovePromptControlModule } from "@/controls/modules/ImprovePromptControlModule";
 import { PromptLibraryControlModule } from "@/controls/modules/PromptLibraryControlModule";
 import { AgentControlModule } from "@/controls/modules/AgentControlModule";
+import { WorkflowControlModule } from "@/controls/modules/WorkflowControlModule";
 
 // Import new/updated Settings Modules
 import { GeneralSettingsModule } from "@/controls/modules/GeneralSettingsModule";
@@ -96,6 +97,7 @@ const controlModulesToRegister: ControlModuleConstructor[] = [
   ImprovePromptControlModule,
   PromptLibraryControlModule,
   AgentControlModule,
+  WorkflowControlModule,
   GitSyncControlModule,
   ManualSyncSidebarControlModule,
   VfsToolsModule,

--- a/src/components/LiteChat/LiteChat.tsx
+++ b/src/components/LiteChat/LiteChat.tsx
@@ -40,6 +40,7 @@ import { uiEvent } from "@/types/litechat/events/ui.events";
 import { settingsEvent } from "@/types/litechat/events/settings.events";
 import { projectEvent } from "@/types/litechat/events/project.events";
 import type { LiteChatModApi } from "@/types/litechat/modding";
+import { WorkflowService } from "@/services/workflow.service";
 
 let initializedControlModules: ControlModule[] = [];
 let appInitializationPromise: Promise<ControlModule[]> | null = null;
@@ -140,6 +141,7 @@ export const LiteChat: React.FC<LiteChatProps> = ({ controls = [] }) => {
     const modApiToUse = coreModApiRef.current;
 
     EventActionCoordinatorService.initialize();
+    WorkflowService.initialize();
 
     const initializeApp = async () => {
       if (hasInitializedSuccessfully) {

--- a/src/components/LiteChat/canvas/InteractionCard.tsx
+++ b/src/components/LiteChat/canvas/InteractionCard.tsx
@@ -16,6 +16,7 @@ import { useShallow } from "zustand/react/shallow";
 import { CardHeader } from "@/components/LiteChat/canvas/interaction/CardHeader";
 import { AssistantResponse } from "@/components/LiteChat/canvas/interaction/AssistantResponse";
 import type { CanvasControl, CanvasControlRenderContext } from "@/types/litechat/canvas/control";
+import { WorkflowStatusDisplay } from './interaction/WorkflowStatusDisplay';
 
 interface InteractionCardProps {
   interaction: Interaction;
@@ -116,6 +117,37 @@ export const InteractionCard: React.FC<InteractionCardProps> = React.memo(
     );
     const contentSlot = renderSlot?.("content", interaction);
     const menuSlot = renderSlot?.("menu", interaction);
+
+    // Special renderer for workflow runs
+    if (interaction.type === 'workflow.run') {
+        return (
+            <div
+                ref={cardRef}
+                className={cn(
+                    "group/card relative rounded-lg border bg-card p-3 md:p-4 shadow-sm",
+                    "overflow-wrap-anywhere",
+                    isError ? "border-destructive/50 bg-destructive/5" : "border-border",
+                    className
+                )}
+            >
+                {showPrompt && interaction.prompt && (
+                    <UserPromptDisplay
+                        turnData={interaction.prompt}
+                        timestamp={interaction.startedAt}
+                        isAssistantComplete={isComplete}
+                        interactionId={interaction.id}
+                    />
+                )}
+                <div className={cn(
+                    "relative group/assistant",
+                    showPrompt && interaction.prompt ? "mt-3 pt-3 border-t border-border/50" : ""
+                )}>
+                    <WorkflowStatusDisplay interaction={interaction} />
+                    {/* Child interactions (steps) will be rendered in tabs by ResponseTabsContainer */}
+                </div>
+            </div>
+        )
+    }
 
     return (
       <div

--- a/src/components/LiteChat/canvas/interaction/HumanInTheLoopControl.tsx
+++ b/src/components/LiteChat/canvas/interaction/HumanInTheLoopControl.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import type { WorkflowRun } from '@/types/litechat/workflow';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { workflowEvent } from '@/types/litechat/events/workflow.events';
+import { emitter } from '@/lib/litechat/event-emitter';
+
+interface HumanInTheLoopControlProps {
+    run: WorkflowRun | null;
+}
+
+export const HumanInTheLoopControl: React.FC<HumanInTheLoopControlProps> = ({ run }) => {
+    const [resumeData, setResumeData] = useState('');
+
+    if (!run) {
+        return null;
+    }
+
+    const currentStep = run.template.steps[run.currentStepIndex];
+
+    const handleResume = () => {
+        let parsedData = resumeData;
+        try {
+            // Try to parse if it's JSON, otherwise use as string
+            parsedData = JSON.parse(resumeData);
+        } catch (e) {
+            // Not JSON, treat as raw string
+        }
+        emitter.emit(workflowEvent.resumeRequest, { runId: run.runId, resumeData: parsedData });
+    };
+
+    return (
+        <div className="p-4 border-t space-y-3">
+            <h3 className="font-semibold text-base">Action Required</h3>
+            <p className="text-sm text-muted-foreground">
+                {currentStep.instructionsForHuman || "Please review the data below and click Continue."}
+            </p>
+            <div className="space-y-1">
+                <Label htmlFor={`hitl-data-${run.runId}`}>Data (edit if needed)</Label>
+                <Textarea
+                    id={`hitl-data-${run.runId}`}
+                    defaultValue={JSON.stringify(run.stepOutputs, null, 2)}
+                    onChange={(e) => setResumeData(e.target.value)}
+                    rows={8}
+                    className="font-mono text-xs"
+                />
+            </div>
+            <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => emitter.emit(workflowEvent.cancelRequest, { runId: run.runId })}>
+                    Cancel Workflow
+                </Button>
+                <Button onClick={handleResume}>
+                    Continue
+                </Button>
+            </div>
+        </div>
+    );
+}; 

--- a/src/components/LiteChat/canvas/interaction/WorkflowStatusDisplay.tsx
+++ b/src/components/LiteChat/canvas/interaction/WorkflowStatusDisplay.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import type { Interaction } from '@/types/litechat/interaction';
+import { useWorkflowStore } from '@/store/workflow.store';
+import { Loader2, CircleCheck, CircleX, Hourglass, UserCheck } from 'lucide-react';
+import { HumanInTheLoopControl } from './HumanInTheLoopControl';
+
+interface WorkflowStatusDisplayProps {
+    interaction: Interaction;
+}
+
+export const WorkflowStatusDisplay: React.FC<WorkflowStatusDisplayProps> = ({ interaction }) => {
+    const activeRun = useWorkflowStore(state => state.activeRun);
+
+    const workflowName = interaction.metadata?.workflowName || 'Workflow';
+    const status = activeRun?.mainInteractionId === interaction.id ? activeRun.status : interaction.status;
+    const currentStep = activeRun?.mainInteractionId === interaction.id ? activeRun.currentStepIndex : 0;
+    const totalSteps = activeRun?.mainInteractionId === interaction.id ? activeRun.template.steps.length : 0;
+
+    let Icon = Loader2;
+    let text = `${workflowName}: Initializing...`;
+    let color = "text-muted-foreground";
+
+    switch (status) {
+        case "RUNNING":
+        case "STREAMING":
+            Icon = Loader2;
+            text = `${workflowName}: Running step ${currentStep + 1} of ${totalSteps}...`;
+            color = "text-blue-500";
+            break;
+        case "PAUSED":
+            Icon = UserCheck;
+            text = `${workflowName}: Paused - Awaiting your input`;
+            color = "text-yellow-500";
+            break;
+        case "COMPLETED":
+            Icon = CircleCheck;
+            text = `${workflowName}: Completed successfully.`;
+            color = "text-green-500";
+            break;
+        case "ERROR":
+            Icon = CircleX;
+            text = `${workflowName}: Failed.`;
+            color = "text-red-500";
+            break;
+        case "CANCELLED":
+            Icon = CircleX;
+            text = `${workflowName}: Cancelled.`;
+            color = "text-muted-foreground";
+            break;
+    }
+
+    return (
+        <div className="p-4 space-y-4">
+            <div className={`flex items-center gap-3 font-semibold text-lg ${color}`}>
+                <Icon className={`h-6 w-6 ${status === 'RUNNING' || status === 'STREAMING' ? 'animate-spin' : ''}`} />
+                <h2>{text}</h2>
+            </div>
+            {status === 'PAUSED' && <HumanInTheLoopControl run={activeRun} />}
+            {status === 'ERROR' && activeRun?.error && (
+                <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md text-destructive text-sm">
+                    <strong>Error:</strong> {activeRun.error}
+                </div>
+            )}
+        </div>
+    );
+}; 

--- a/src/controls/components/workflow/WorkflowBuilder.tsx
+++ b/src/controls/components/workflow/WorkflowBuilder.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import type { WorkflowControlModule } from '@/controls/modules/WorkflowControlModule';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Bot, Plus, User } from 'lucide-react';
+import { ActionTooltipButton } from '@/components/LiteChat/common/ActionTooltipButton';
+import type { WorkflowStep, WorkflowTemplate } from '@/types/litechat/workflow';
+import { WorkflowStepCard } from './WorkflowStepCard';
+
+interface WorkflowBuilderProps {
+    module: WorkflowControlModule;
+}
+
+export const WorkflowBuilder: React.FC<WorkflowBuilderProps> = ({ module }) => {
+    const [open, setOpen] = useState(false);
+    const [workflow, setWorkflow] = useState<WorkflowTemplate>({
+        id: '',
+        name: 'My New Workflow',
+        description: 'A workflow for processing things.',
+        steps: [],
+        createdAt: '',
+        updatedAt: '',
+    });
+    const [initialPrompt, setInitialPrompt] = useState('');
+
+    const promptTemplates = module.getPromptTemplates();
+    const agentTasks = module.getAgentTasks();
+
+    const handleAddStep = () => {
+        const newStep: WorkflowStep = {
+            id: `step_${workflow.steps.length + 1}`,
+            name: `Step ${workflow.steps.length + 1}`,
+            type: 'prompt',
+        };
+        setWorkflow(prev => ({ ...prev, steps: [...prev.steps, newStep] }));
+    };
+
+    const handleStepChange = (updatedStep: WorkflowStep) => {
+        setWorkflow(prev => ({
+            ...prev,
+            steps: prev.steps.map(s => s.id === updatedStep.id ? updatedStep : s)
+        }));
+    };
+
+    const handleRunWorkflow = () => {
+        module.startWorkflow(workflow, initialPrompt);
+        setOpen(false);
+    };
+
+    return (
+        <>
+            <ActionTooltipButton
+                tooltipText="Open Workflow Builder"
+                onClick={() => setOpen(true)}
+                aria-label="Open Workflow Builder"
+                disabled={module.getIsStreaming()}
+                icon={<Bot />}
+                className="h-5 w-5 md:h-6 md:w-6"
+            />
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent className="min-w-[85vw] min-h-[75vh] flex flex-col p-4">
+                    <DialogHeader>
+                        <DialogTitle>Workflow Builder</DialogTitle>
+                        <DialogDescription>
+                            Create a sequence of steps to automate tasks. The output of one step can be used as input for the next.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 flex-grow overflow-hidden">
+                        {/* Left Side: Workflow Configuration */}
+                        <div className="flex flex-col gap-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="wf-name">Workflow Name</Label>
+                                <Input
+                                    id="wf-name"
+                                    value={workflow.name}
+                                    onChange={e => setWorkflow(prev => ({ ...prev, name: e.target.value }))}
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="wf-desc">Description</Label>
+                                <Textarea
+                                    id="wf-desc"
+                                    value={workflow.description}
+                                    onChange={e => setWorkflow(prev => ({ ...prev, description: e.target.value }))}
+                                    rows={3}
+                                />
+                            </div>
+                            <div className="space-y-2 flex-grow flex flex-col">
+                                <Label>Initial Prompt (Your Message)</Label>
+                                <Textarea
+                                    value={initialPrompt}
+                                    onChange={e => setInitialPrompt(e.target.value)}
+                                    placeholder="Enter the first message to start the workflow..."
+                                    className="flex-grow"
+                                />
+                            </div>
+                        </div>
+
+                        {/* Right Side: Steps */}
+                        <div className="flex flex-col gap-4 overflow-hidden">
+                            <Label>Workflow Steps ({workflow.steps.length})</Label>
+                            <ScrollArea className="border rounded-md p-3 flex-grow">
+                                <div className="space-y-4">
+                                    {workflow.steps.map((step, index) => (
+                                        <WorkflowStepCard
+                                            key={step.id}
+                                            step={step}
+                                            onChange={handleStepChange}
+                                            promptTemplates={promptTemplates}
+                                            agentTasks={agentTasks}
+                                        />
+                                    ))}
+                                    {workflow.steps.length === 0 && (
+                                        <div className="text-center text-muted-foreground py-8">
+                                            No steps yet. Add one to get started.
+                                        </div>
+                                    )}
+                                </div>
+                            </ScrollArea>
+                            <Button variant="outline" onClick={handleAddStep}>
+                                <Plus className="mr-2 h-4 w-4" />
+                                Add Step
+                            </Button>
+                        </div>
+                    </div>
+
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+                        <Button onClick={handleRunWorkflow} disabled={!initialPrompt || workflow.steps.length === 0}>
+                            Run Workflow
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}; 

--- a/src/controls/components/workflow/WorkflowStepCard.tsx
+++ b/src/controls/components/workflow/WorkflowStepCard.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import type { WorkflowStep } from '@/types/litechat/workflow';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { PromptTemplate } from '@/types/litechat/prompt-template';
+
+interface WorkflowStepCardProps {
+    step: WorkflowStep;
+    onChange: (updatedStep: WorkflowStep) => void;
+    promptTemplates: PromptTemplate[];
+    agentTasks: PromptTemplate[];
+}
+
+export const WorkflowStepCard: React.FC<WorkflowStepCardProps> = ({ step, onChange, promptTemplates, agentTasks }) => {
+    
+    const templatesToShow = step.type === 'prompt' ? promptTemplates : agentTasks;
+
+    return (
+        <div className="p-4 border rounded-lg space-y-3 bg-muted/20">
+            <div className="space-y-1">
+                <Label htmlFor={`step-name-${step.id}`}>Step Name</Label>
+                <Input
+                    id={`step-name-${step.id}`}
+                    value={step.name}
+                    onChange={(e) => onChange({ ...step, name: e.target.value })}
+                />
+            </div>
+            <div className="space-y-1">
+                <Label htmlFor={`step-type-${step.id}`}>Step Type</Label>
+                <Select
+                    value={step.type}
+                    onValueChange={(value) => onChange({ ...step, type: value as WorkflowStep['type'], templateId: undefined })}
+                >
+                    <SelectTrigger id={`step-type-${step.id}`}>
+                        <SelectValue placeholder="Select step type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="prompt">AI Prompt</SelectItem>
+                        <SelectItem value="agent-task">Agent Task</SelectItem>
+                        <SelectItem value="human-in-the-loop">Human in the Loop</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+            {(step.type === 'prompt' || step.type === 'agent-task') && (
+                <div className="space-y-1">
+                    <Label htmlFor={`step-template-${step.id}`}>Template</Label>
+                    <Select
+                        value={step.templateId}
+                        onValueChange={(value) => onChange({ ...step, templateId: value })}
+                    >
+                        <SelectTrigger id={`step-template-${step.id}`}>
+                            <SelectValue placeholder="Select a template" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {templatesToShow.map(template => (
+                                <SelectItem key={template.id} value={template.id}>
+                                    {template.name}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            )}
+            {step.type === 'human-in-the-loop' && (
+                <div className="space-y-1">
+                    <Label htmlFor={`step-instructions-${step.id}`}>Instructions for Human</Label>
+                    <Input
+                        id={`step-instructions-${step.id}`}
+                        value={step.instructionsForHuman || ''}
+                        onChange={(e) => onChange({ ...step, instructionsForHuman: e.target.value })}
+                        placeholder="e.g., 'Review and approve the summary.'"
+                    />
+                </div>
+            )}
+        </div>
+    );
+}; 

--- a/src/controls/modules/WorkflowControlModule.ts
+++ b/src/controls/modules/WorkflowControlModule.ts
@@ -1,0 +1,78 @@
+import React from "react";
+import { type ControlModule } from "@/types/litechat/control";
+import { type LiteChatModApi } from "@/types/litechat/modding";
+import { workflowEvent } from "@/types/litechat/events/workflow.events";
+import { WorkflowBuilder } from "@/controls/components/workflow/WorkflowBuilder";
+import type { WorkflowTemplate } from "@/types/litechat/workflow";
+import { useInteractionStore } from "@/store/interaction.store";
+import { promptTemplateEvent } from "@/types/litechat/events/prompt-template.events";
+import type { PromptTemplate } from "@/types/litechat/prompt-template";
+
+export class WorkflowControlModule implements ControlModule {
+  readonly id = "core-workflow-control";
+  private modApi: LiteChatModApi | null = null;
+  private isStreaming = false;
+  private notifyComponentUpdate: (() => void) | null = null;
+  private eventUnsubscribers: (() => void)[] = [];
+  private allTemplates: PromptTemplate[] = [];
+
+  async initialize(modApi: LiteChatModApi): Promise<void> {
+    this.modApi = modApi;
+    this.isStreaming = useInteractionStore.getState().status === "streaming";
+
+    const unsubStatus = modApi.on("interaction.status.changed", (payload) => {
+      if (typeof payload === "object" && payload && "status" in payload) {
+        const newStreamingStatus = payload.status === "streaming";
+        if (this.isStreaming !== newStreamingStatus) {
+          this.isStreaming = newStreamingStatus;
+          this.notifyComponentUpdate?.();
+        }
+      }
+    });
+
+    const unsubTemplatesChanged = modApi.on(promptTemplateEvent.promptTemplatesChanged, (payload) => {
+        if (payload?.promptTemplates) {
+            this.allTemplates = payload.promptTemplates;
+            this.notifyComponentUpdate?.();
+        }
+    });
+
+    this.eventUnsubscribers.push(unsubStatus, unsubTemplatesChanged);
+    
+    // Request templates on initialization
+    modApi.emit(promptTemplateEvent.loadPromptTemplatesRequest, {});
+  }
+
+  // --- Public API for the Component ---
+  
+  public getIsStreaming = (): boolean => this.isStreaming;
+  public getPromptTemplates = (): PromptTemplate[] => this.allTemplates.filter(t => (t.type || 'prompt') === 'prompt');
+  public getAgentTasks = (): PromptTemplate[] => this.allTemplates.filter(t => t.type === 'agent' || t.type === 'task');
+
+  public setNotifyCallback = (cb: (() => void) | null): void => {
+    this.notifyComponentUpdate = cb;
+  };
+
+  public startWorkflow = (template: WorkflowTemplate, initialPrompt: string): void => {
+    this.modApi?.emit(workflowEvent.startRequest, { template, initialPrompt });
+  };
+
+  // --- ControlModule Implementation ---
+
+  register(modApi: LiteChatModApi): void {
+    this.modApi = modApi;
+    modApi.registerPromptControl({
+      id: this.id,
+      status: () => "ready",
+      triggerRenderer: () => React.createElement(WorkflowBuilder, { module: this }),
+    });
+  }
+
+  destroy(): void {
+    this.eventUnsubscribers.forEach((unsub) => unsub());
+    this.eventUnsubscribers = [];
+    this.notifyComponentUpdate = null;
+    this.modApi = null;
+    console.log(`[${this.id}] Destroyed.`);
+  }
+} 

--- a/src/lib/litechat/prompt-util.ts
+++ b/src/lib/litechat/prompt-util.ts
@@ -1,0 +1,53 @@
+import type { PromptTemplate, PromptFormData, CompiledPrompt } from "@/types/litechat/prompt-template";
+
+/**
+ * Replaces placeholders in a template string with corresponding values from a FormData object.
+ *
+ * @param content - The template string with placeholders (e.g., "Hello, {{name}}").
+ * @param variables - An array of variable definitions for the template.
+ * @param formData - An object containing the data to fill in the placeholders.
+ * @returns The content with placeholders filled.
+ */
+function fillPlaceholders(content: string, variables: PromptTemplate['variables'], formData: PromptFormData): string {
+    let filledContent = content;
+    if (!variables) {
+        return filledContent;
+    }
+    variables.forEach(variable => {
+        const placeholder = `{{${variable.name}}}`;
+        const value = formData[variable.name];
+
+        if (value !== undefined) {
+            // For array values (e.g., from multi-select), join them into a string
+            const replacement = Array.isArray(value) ? value.join(', ') : String(value);
+            filledContent = filledContent.replace(new RegExp(placeholder, 'g'), replacement);
+        }
+    });
+    return filledContent;
+}
+
+
+/**
+ * Compiles a prompt template with the given form data.
+ * It fills placeholders, selects tools, and selects rules.
+ *
+ * @param template - The PromptTemplate object to compile.
+ * @param formData - The form data to use for compilation.
+ * @returns A promise that resolves to the compiled prompt.
+ */
+export async function compilePromptTemplate(template: PromptTemplate, formData: PromptFormData): Promise<CompiledPrompt> {
+    const variables = template.variables || [];
+    
+    // Fill in the main content
+    const compiledContent = fillPlaceholders(template.prompt, variables, formData);
+    
+    // TODO: Add logic for selecting tools and rules based on formData if needed in the future
+    const selectedTools = template.tools || [];
+    const selectedRules = template.rules || [];
+
+    return {
+        content: compiledContent,
+        selectedTools: selectedTools,
+        selectedRules: selectedRules
+    };
+} 

--- a/src/services/event-action-coordinator.service.ts
+++ b/src/services/event-action-coordinator.service.ts
@@ -18,6 +18,7 @@ import { useVfsStore } from "@/store/vfs.store";
 import { useControlRegistryStore } from "@/store/control.store";
 import { usePromptTemplateStore } from "@/store/prompt-template.store";
 import { useMcpStore } from "@/store/mcp.store";
+import { useWorkflowStore } from "@/store/workflow.store";
 
 // Array of all store hooks that have the getRegisteredActionHandlers method
 const storesWithActionHandlers = [
@@ -35,6 +36,7 @@ const storesWithActionHandlers = [
   useControlRegistryStore,
   usePromptTemplateStore,
   useMcpStore,
+  useWorkflowStore,
 ];
 
 export class EventActionCoordinatorService {

--- a/src/services/workflow.service.ts
+++ b/src/services/workflow.service.ts
@@ -1,0 +1,320 @@
+import { emitter } from "@/lib/litechat/event-emitter";
+import { workflowEvent, type WorkflowEventPayloads } from "@/types/litechat/events/workflow.events";
+import { interactionEvent } from "@/types/litechat/events/interaction.events";
+import type { Interaction } from "@/types/litechat/interaction";
+import { InteractionService } from "./interaction.service";
+import { useWorkflowStore } from "@/store/workflow.store";
+import { useConversationStore } from "@/store/conversation.store";
+import type { WorkflowRun, WorkflowStep } from "@/types/litechat/workflow";
+import { nanoid } from "nanoid";
+import { compilePromptTemplate } from "@/lib/litechat/prompt-util";
+import type { PromptTemplate } from "@/types/litechat/prompt-template";
+
+class WorkflowServiceImpl {
+  private isInitialized = false;
+  private eventUnsubscribers: (() => void)[] = [];
+
+  public initialize(): void {
+    if (this.isInitialized) {
+      return;
+    }
+
+    const unsubStart = emitter.on(workflowEvent.startRequest, this.handleWorkflowStartRequest);
+    const unsubResume = emitter.on(workflowEvent.resumeRequest, this.handleWorkflowResumeRequest);
+    const unsubInteractionCompleted = emitter.on(interactionEvent.completed, this.handleInteractionCompleted);
+
+    // @ts-expect-error - this is a workaround, TS is throwing, IDNW
+    this.eventUnsubscribers.push(unsubStart, unsubResume, unsubInteractionCompleted);
+    this.isInitialized = true;
+    console.log("[WorkflowService] Initialized.");
+  }
+
+  private async _compileStepPrompt(step: WorkflowStep, context: Record<string, any>): Promise<string> {
+    if (!step.prompt) {
+      return "";
+    }
+
+    // The workflow context is flat: { step_1_id: { output: ... }, step_2_id: { ... } }
+    // The prompt template variables are just `variableName`.
+    // We need to create the form data object that the compiler expects.
+    const formData: Record<string, any> = {};
+
+    // This regex will find all {{...}} placeholders in the prompt
+    const placeholderRegex = /\{\{(.*?)\}\}/g;
+    let match;
+    while ((match = placeholderRegex.exec(step.prompt)) !== null) {
+      const fullPath = match[1].trim(); // e.g., "step_1.output.username"
+      const pathParts = fullPath.split('.');
+      const varName = pathParts[pathParts.length - 1]; // "username"
+      
+      let value: any = context;
+      try {
+        for (const k of pathParts) {
+            if (value && typeof value === 'object' && k in value) {
+                value = value[k];
+            } else {
+                // Path is invalid in the current context
+                throw new Error(`Could not resolve path: ${fullPath}`);
+            }
+        }
+        formData[varName] = value;
+      } catch (e) {
+         console.warn(`[WorkflowService] Could not resolve template variable: ${fullPath}`);
+      }
+    }
+
+    // Create a temporary, ad-hoc PromptTemplate object for the compiler
+    const tempTemplate: PromptTemplate = {
+      id: step.id,
+      name: step.name,
+      description: '',
+      prompt: step.prompt,
+      variables: Object.keys(formData).map(name => ({ name, type: 'string', required: true, description: '' })),
+      tags: [],
+      isPublic: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const compiled = await compilePromptTemplate(tempTemplate, formData);
+    return compiled.content;
+  }
+
+  private handleWorkflowStartRequest = async (payload: WorkflowEventPayloads[typeof workflowEvent.startRequest]): Promise<void> => {
+    console.log("[WorkflowService] Workflow start request received", payload);
+    const { template, initialPrompt } = payload;
+
+    try {
+      // Get current conversation ID
+      const conversationId = useConversationStore.getState().selectedItemId;
+      if (!conversationId) {
+        throw new Error("No active conversation selected to start a workflow.");
+      }
+
+      // 1. Create the main 'workflow.run' interaction to act as a container
+      const mainInteraction = await InteractionService.startInteraction(
+        {
+          // The initial prompt is associated with the main workflow interaction
+          messages: [{ role: 'user', content: initialPrompt }],
+          system: "Executing workflow...", // Placeholder system prompt
+          parameters: {}, // Add empty parameters to satisfy PromptObject type
+          metadata: { isWorkflowRun: true, workflowName: template.name },
+        },
+        conversationId, // Use current conversation
+        {
+          id: nanoid(),
+          content: initialPrompt,
+          parameters: {}, // Add empty parameters
+          metadata: { isWorkflowRun: true, workflowName: template.name },
+        },
+        "workflow.run"
+      );
+
+      if (!mainInteraction) {
+        throw new Error("Failed to create the main workflow interaction.");
+      }
+
+      // 2. Create the WorkflowRun state object
+      const run: WorkflowRun = {
+        runId: nanoid(),
+        mainInteractionId: mainInteraction.id,
+        template: template,
+        status: "RUNNING",
+        currentStepIndex: 0,
+        stepOutputs: {},
+        startedAt: new Date().toISOString(),
+      };
+
+      // 3. Emit workflowEvent.started to update the store and any other listeners
+      emitter.emit(workflowEvent.started, { run });
+
+      // 4. Trigger the first step
+      this.runNextStep(run);
+
+    } catch (error) {
+      console.error("[WorkflowService] Error starting workflow:", error);
+      emitter.emit(workflowEvent.error, { runId: "", error: String(error) });
+    }
+  };
+
+  private runNextStep = async (run: WorkflowRun): Promise<void> => {
+    console.log(`[WorkflowService] Running step ${run.currentStepIndex} for run ${run.runId}`);
+
+    // Check if the workflow is complete
+    if (run.currentStepIndex >= run.template.steps.length) {
+      emitter.emit(workflowEvent.completed, { runId: run.runId, finalOutput: run.stepOutputs });
+      console.log(`[WorkflowService] Workflow ${run.runId} completed.`);
+      return;
+    }
+
+    const currentStep = run.template.steps[run.currentStepIndex];
+    const conversationId = useConversationStore.getState().selectedItemId;
+
+    if (!conversationId) {
+      emitter.emit(workflowEvent.error, { runId: run.runId, error: "No active conversation found during step execution." });
+      return;
+    }
+
+    try {
+      if (currentStep.type === "human-in-the-loop") {
+        // Pause the workflow and wait for human input
+        emitter.emit(workflowEvent.paused, { runId: run.runId, dataForReview: run.stepOutputs });
+        console.log(`[WorkflowService] Workflow ${run.runId} paused for human in the loop.`);
+
+      } else if (currentStep.type === "prompt" || currentStep.type === "agent-task") {
+        // 1. Compile the prompt template with data from previous steps
+        const promptText = await this._compileStepPrompt(currentStep, run.stepOutputs);
+
+        // 2. Construct a system prompt to enforce structured JSON output if required
+        let systemPrompt = "Executing workflow step...";
+        if (currentStep.structuredOutput?.jsonSchema) {
+          systemPrompt = `You are an expert at following instructions. Your response MUST be a single JSON object that strictly conforms to the following JSON Schema. Do not include any other text, explanations, or markdown formatting like \`\`\`json. Your response must be only the JSON object itself.
+
+JSON Schema:
+${JSON.stringify(currentStep.structuredOutput.jsonSchema, null, 2)}`;
+        }
+
+        // Create a child interaction for this step
+        await InteractionService.startInteraction(
+          {
+            messages: [{ role: 'user', content: promptText }],
+            system: systemPrompt,
+            parameters: {},
+            metadata: {
+              isWorkflowStep: true,
+              workflowRunId: run.runId,
+              workflowStepId: currentStep.id,
+              workflowStepName: currentStep.name,
+            },
+          },
+          conversationId,
+          {
+            id: nanoid(),
+            content: promptText,
+            parameters: {},
+            metadata: {
+              isWorkflowStep: true,
+              workflowRunId: run.runId,
+              workflowStepId: currentStep.id,
+            },
+          },
+          "message.assistant_regen" // Use regen to show it as a child
+        );
+      }
+    } catch (error) {
+      console.error(`[WorkflowService] Error running step ${currentStep.id} for run ${run.runId}:`, error);
+      emitter.emit(workflowEvent.error, { runId: run.runId, error: `Failed on step "${currentStep.name}": ${String(error)}` });
+    }
+  };
+
+  private handleWorkflowResumeRequest = async (payload: WorkflowEventPayloads[typeof workflowEvent.resumeRequest]): Promise<void> => {
+    console.log("[WorkflowService] Workflow resume request received", payload);
+    const { runId, resumeData } = payload;
+    const activeRun = useWorkflowStore.getState().activeRun;
+
+    if (!activeRun || activeRun.runId !== runId || activeRun.status !== "PAUSED") {
+      console.warn(`[WorkflowService] Ignoring resume request for invalid or non-paused run ${runId}`);
+      return;
+    }
+
+    const currentStep = activeRun.template.steps[activeRun.currentStepIndex];
+
+    // Save the human's input as the output of this HITL step
+    emitter.emit(workflowEvent.stepCompleted, { 
+      runId: activeRun.runId, 
+      stepId: currentStep.id, 
+      output: resumeData 
+    });
+
+    // Notify that the workflow is resuming
+    emitter.emit(workflowEvent.resumed, { runId: activeRun.runId });
+    
+    // The store will update the state, so we get the latest version
+    const nextRunState = useWorkflowStore.getState().activeRun;
+    if(nextRunState) {
+      this.runNextStep(nextRunState);
+    }
+  };
+
+  private handleInteractionCompleted = (payload: { interactionId: string; status: string; interaction?: Interaction }): void => {
+    const activeRun = useWorkflowStore.getState().activeRun;
+    // Ensure there's an active, running workflow
+    if (!activeRun || activeRun.status !== "RUNNING") {
+      return;
+    }
+    
+    // Check if the completed interaction is a step in our active workflow
+    const interaction = payload.interaction;
+    if (
+      !interaction || 
+      !interaction.metadata?.isWorkflowStep ||
+      interaction.metadata?.workflowRunId !== activeRun.runId
+    ) {
+      return;
+    }
+
+    console.log(`[WorkflowService] Handling completed interaction for step ${interaction.metadata.workflowStepId}`);
+
+    const currentStep = activeRun.template.steps[activeRun.currentStepIndex];
+
+    // Ensure the completed step is the one we're waiting for
+    if (interaction.metadata.workflowStepId !== currentStep.id) {
+      console.warn(`[WorkflowService] Received completion for an unexpected step. Expected: ${currentStep.id}, Received: ${interaction.metadata.workflowStepId}`);
+      return;
+    }
+
+    if (payload.status === "ERROR") {
+      emitter.emit(workflowEvent.error, { runId: activeRun.runId, error: `Step "${currentStep.name}" failed.` });
+      return;
+    }
+
+    // Attempt to parse structured output if the step was configured for it
+    let stepOutput: any = interaction.response ?? "No output";
+    const stepSpec = activeRun.template.steps.find(s => s.id === interaction.metadata?.workflowStepId);
+
+    if (stepSpec?.structuredOutput) {
+      console.log(`[WorkflowService] Step ${stepSpec.id} requires structured output. Parsing response...`);
+      try {
+        // Attempt to extract JSON from markdown code blocks, or assume the whole response is JSON
+        const jsonRegex = /```json\s*([\s\S]*?)\s*```/;
+        const match = interaction.response?.match(jsonRegex);
+        const jsonString = match ? match[1].trim() : interaction.response?.trim();
+        
+        if (jsonString) {
+          stepOutput = JSON.parse(jsonString);
+          console.log(`[WorkflowService] Successfully parsed structured output for step ${stepSpec.id}.`);
+        } else {
+          throw new Error("Empty response, cannot parse JSON.");
+        }
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        console.error(`[WorkflowService] Failed to parse structured output for step ${stepSpec.id}. Error: ${errorMessage}. Storing raw response instead.`);
+        // Keep stepOutput as the raw response on failure
+        emitter.emit(workflowEvent.error, { runId: activeRun.runId, error: `Step "${stepSpec.name}" failed to produce valid JSON.` });
+        return; // Halt workflow execution on parsing failure
+      }
+    }
+
+    // Emit event to notify store of step completion
+    emitter.emit(workflowEvent.stepCompleted, { 
+      runId: activeRun.runId, 
+      stepId: currentStep.id, 
+      output: stepOutput 
+    });
+
+    // The store updates the activeRun state. We must get the fresh state before proceeding.
+    const nextRunState = useWorkflowStore.getState().activeRun;
+    if (nextRunState) {
+      this.runNextStep(nextRunState);
+    }
+  };
+
+  public destroy(): void {
+    this.eventUnsubscribers.forEach(unsub => unsub());
+    this.eventUnsubscribers = [];
+    this.isInitialized = false;
+    console.log("[WorkflowService] Destroyed.");
+  }
+}
+
+export const WorkflowService = new WorkflowServiceImpl(); 

--- a/src/store/workflow.store.ts
+++ b/src/store/workflow.store.ts
@@ -1,0 +1,125 @@
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import type { WorkflowRun, WorkflowRunStatus } from "@/types/litechat/workflow";
+import type { RegisteredActionHandler } from "@/types/litechat/control";
+import { workflowEvent, type WorkflowEventPayloads } from "@/types/litechat/events/workflow.events";
+import { emitter } from "@/lib/litechat/event-emitter";
+
+export interface WorkflowState {
+  activeRun: WorkflowRun | null;
+}
+
+export interface WorkflowActions {
+  // Internal actions triggered by events
+  _handleWorkflowStarted: (run: WorkflowRun) => void;
+  _handleStepCompleted: (runId: string, stepId: string, output: any) => void;
+  _handleWorkflowPaused: (runId: string) => void;
+  _handleWorkflowResumed: (runId: string) => void;
+  _handleWorkflowCompleted: (runId: string) => void;
+  _handleWorkflowError: (runId: string, error: string) => void;
+  _handleWorkflowCancelled: (runId: string) => void;
+  _updateRun: (runId: string, status: WorkflowRunStatus, updateFn?: (run: WorkflowRun) => void) => void;
+  
+  // For the EventActionCoordinator
+  getRegisteredActionHandlers: () => RegisteredActionHandler[];
+}
+
+export const useWorkflowStore = create(
+  immer<WorkflowState & WorkflowActions>((set, get) => ({
+    activeRun: null,
+
+    _handleWorkflowStarted: (run) => {
+      set((state) => {
+        state.activeRun = run;
+      });
+    },
+
+    _updateRun: (runId, status, updateFn) => {
+      set((state) => {
+        if (state.activeRun && state.activeRun.runId === runId) {
+          state.activeRun.status = status;
+          if (updateFn) {
+            updateFn(state.activeRun);
+          }
+        }
+      });
+    },
+
+    _handleStepCompleted: (runId, stepId, output) => {
+      get()._updateRun(runId, "RUNNING", (run: WorkflowRun) => {
+        run.stepOutputs[stepId] = output;
+        run.currentStepIndex += 1;
+      });
+    },
+
+    _handleWorkflowPaused: (runId) => {
+      get()._updateRun(runId, "PAUSED");
+    },
+
+    _handleWorkflowResumed: (runId) => {
+      get()._updateRun(runId, "RUNNING");
+    },
+
+    _handleWorkflowCompleted: (runId) => {
+      get()._updateRun(runId, "COMPLETED", (run: WorkflowRun) => {
+        run.endedAt = new Date().toISOString();
+      });
+      // Optionally clear after a delay
+      setTimeout(() => set({ activeRun: null }), 5000);
+    },
+
+    _handleWorkflowError: (runId, error) => {
+      get()._updateRun(runId, "ERROR", (run: WorkflowRun) => {
+        run.error = error;
+        run.endedAt = new Date().toISOString();
+      });
+    },
+
+    _handleWorkflowCancelled: (runId) => {
+      if (get().activeRun?.runId === runId) {
+        set({ activeRun: null });
+      }
+    },
+
+    getRegisteredActionHandlers: () => {
+      const actions = get();
+      return [
+        {
+          eventName: workflowEvent.started,
+          handler: (payload: WorkflowEventPayloads[typeof workflowEvent.started]) => actions._handleWorkflowStarted(payload.run),
+          storeId: "WorkflowStore",
+        },
+        {
+          eventName: workflowEvent.stepCompleted,
+          handler: (payload: WorkflowEventPayloads[typeof workflowEvent.stepCompleted]) => actions._handleStepCompleted(payload.runId, payload.stepId, payload.output),
+          storeId: "WorkflowStore",
+        },
+        {
+          eventName: workflowEvent.paused,
+          handler: (payload: WorkflowEventPayloads[typeof workflowEvent.paused]) => actions._handleWorkflowPaused(payload.runId),
+          storeId: "WorkflowStore",
+        },
+        {
+            eventName: workflowEvent.resumed,
+            handler: (payload: WorkflowEventPayloads[typeof workflowEvent.resumed]) => actions._handleWorkflowResumed(payload.runId),
+            storeId: "WorkflowStore",
+        },
+        {
+            eventName: workflowEvent.completed,
+            handler: (payload: WorkflowEventPayloads[typeof workflowEvent.completed]) => actions._handleWorkflowCompleted(payload.runId),
+            storeId: "WorkflowStore",
+        },
+        {
+            eventName: workflowEvent.error,
+            handler: (payload: WorkflowEventPayloads[typeof workflowEvent.error]) => actions._handleWorkflowError(payload.runId, payload.error),
+            storeId: "WorkflowStore",
+        },
+        {
+            eventName: workflowEvent.cancelRequest, // Listen to request to clear state
+            handler: (payload: WorkflowEventPayloads[typeof workflowEvent.cancelRequest]) => actions._handleWorkflowCancelled(payload.runId),
+            storeId: "WorkflowStore",
+        },
+      ];
+    },
+  }))
+); 

--- a/src/types/litechat/events/workflow.events.ts
+++ b/src/types/litechat/events/workflow.events.ts
@@ -1,0 +1,65 @@
+import type { WorkflowTemplate, WorkflowRun } from "../workflow";
+
+export const workflowEvent = {
+  // --- Requests ---
+  // Fired by the UI to start a new workflow
+  startRequest: "workflow.start.request",
+  // Fired by the UI (Human in the Loop control) to resume a paused workflow
+  resumeRequest: "workflow.resume.request",
+  // Fired by the UI to cancel a running workflow
+  cancelRequest: "workflow.cancel.request",
+
+  // --- State Changes ---
+  // Fired by the WorkflowService when a workflow officially starts
+  started: "workflow.started",
+  // Fired by the WorkflowService when a HITL step is encountered
+  paused: "workflow.paused",
+  // Fired by the WorkflowService when a workflow resumes after being paused
+  resumed: "workflow.resumed",
+  // Fired by the WorkflowService after each step completes
+  stepCompleted: "workflow.step.completed",
+  // Fired by the WorkflowService when the entire workflow is finished
+  completed: "workflow.completed",
+  // Fired by the WorkflowService if any unrecoverable error occurs
+  error: "workflow.error",
+} as const;
+
+
+export interface WorkflowEventPayloads {
+  [workflowEvent.startRequest]: {
+    template: WorkflowTemplate;
+    initialPrompt: string; // The first user message that kicks off the workflow
+  };
+  [workflowEvent.resumeRequest]: {
+    runId: string;
+    // The corrected/approved data from the human
+    resumeData?: any; 
+  };
+  [workflowEvent.cancelRequest]: {
+    runId: string;
+  };
+  [workflowEvent.started]: {
+    run: WorkflowRun;
+  };
+  [workflowEvent.paused]: {
+    runId: string;
+    // The data for the human to review
+    dataForReview: any;
+  };
+  [workflowEvent.resumed]: {
+    runId: string;
+  };
+  [workflowEvent.stepCompleted]: {
+    runId: string;
+    stepId: string;
+    output: any;
+  };
+  [workflowEvent.completed]: {
+    runId: string;
+    finalOutput: any;
+  };
+  [workflowEvent.error]: {
+    runId: string;
+    error: string;
+  };
+} 

--- a/src/types/litechat/interaction.ts
+++ b/src/types/litechat/interaction.ts
@@ -12,7 +12,8 @@ export type InteractionType =
   | "prompt.enhance"
   | "tool.execution"
   | "system.info"
-  | "system.error";
+  | "system.error"
+  | "workflow.run";
 
 export type InteractionStatus =
   | "PENDING"
@@ -20,7 +21,8 @@ export type InteractionStatus =
   | "COMPLETED"
   | "ERROR"
   | "WARNING"
-  | "CANCELLED";
+  | "CANCELLED"
+  | "PAUSED";
 
 // Represents one logical unit in the conversation flow
 export interface Interaction {

--- a/src/types/litechat/modding.ts
+++ b/src/types/litechat/modding.ts
@@ -24,6 +24,7 @@ import { type McpEventPayloads } from "./events/mcp.events";
 import { type BlockRendererEventPayloads } from "./events/block-renderer.events";
 import type { CanvasControl as CoreCanvasControlFromTypes } from "./canvas/control";
 import type { BlockRenderer } from "./canvas/block-renderer";
+import { type WorkflowEventPayloads } from "./events/workflow.events";
 
 import {
   type ModMiddlewareHookName,
@@ -171,6 +172,7 @@ export type ModEventPayloadMap = AppEventPayloads &
   ControlRegistryEventPayloads &
   BlockRendererEventPayloads &
   McpEventPayloads &
+  WorkflowEventPayloads &
   Record<string, any>;
 
 interface BaseControl {

--- a/src/types/litechat/workflow.ts
+++ b/src/types/litechat/workflow.ts
@@ -1,0 +1,47 @@
+export type WorkflowStepType = "prompt" | "agent-task" | "human-in-the-loop";
+
+export interface WorkflowStep {
+  id: string; // nanoid
+  name: string; // User-defined name for the step
+  type: WorkflowStepType;
+
+  // For 'prompt' or 'agent-task' types
+  templateId?: string; // ID of the PromptTemplate
+  
+  // For 'human-in-the-loop'
+  instructionsForHuman?: string; // e.g., "Please review the summary and make any necessary corrections."
+
+  // Defines how to map output from the *previous* step to the input variables of *this* step.
+  // The keys are the variable names in this step's template (e.g., 'customer_email').
+  // The values are JSONPath-like strings to extract data from the previous step's structured output (e.g., '$.user.email').
+  inputMapping?: Record<string, string>;
+
+  prompt?: string; // The prompt template for this step
+  structuredOutput?: {
+    schema: Record<string, 'string' | 'number' | 'boolean' | 'object' | 'array'>;
+    jsonSchema: object;
+  };
+}
+
+export interface WorkflowTemplate {
+  id: string; // nanoid
+  name: string;
+  description: string;
+  steps: WorkflowStep[];
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
+
+export type WorkflowRunStatus = "IDLE" | "RUNNING" | "PAUSED" | "COMPLETED" | "ERROR";
+
+export interface WorkflowRun {
+  runId: string; // Unique ID for this specific run
+  mainInteractionId: string; // The ID of the parent 'workflow.run' interaction
+  template: WorkflowTemplate;
+  status: WorkflowRunStatus;
+  currentStepIndex: number;
+  stepOutputs: Record<string, any>; // Store any kind of output, including structured JSON
+  error?: string; // Error message if the workflow fails
+  startedAt: string; // ISO 8601
+  completedAt?: string; // ISO 8601
+} 

--- a/workflow_plan.md
+++ b/workflow_plan.md
@@ -1,0 +1,71 @@
+# LiteChat Workflow Feature: Development Plan
+
+## 1. Overview & Goals
+
+This document outlines the development plan for a new "Workflow" feature in LiteChat, designed to chain multiple AI prompts, tasks, and other actions into a sequential, automated process.
+
+### High-Level Goals
+- **Sequential Task Execution**: Chain multiple prompts, agent tasks, and other actions.
+- **Structured Data Passing**: Use the output of one step as the input for the next.
+- **Human in the Loop (HITL)**: Allow for steps that pause the workflow for manual user intervention.
+- **Architectural Consistency**: Strictly follow LiteChat's established patterns of event-driven orchestration and parent-child interaction relationships.
+- **Foundation for Future Features**: This engine will be robust enough to eventually replace the `Race-Combine` feature.
+
+## 2. Architecture
+
+### 2.1. The Workflow Interaction Model
+Workflows will be represented in the chat canvas using the existing `Interaction` model:
+- **Parent Interaction (`workflow.run`)**: A new `InteractionType` that acts as the main container for the entire workflow.
+- **Child Interactions**: Each step in the workflow will be a separate, child `Interaction` (e.g., `message.assistant_regen`), whose `parentId` points to the `workflow.run` interaction. These will appear as tabs.
+- **Paused Status**: A new `InteractionStatus` of `PAUSED` will be added to support the HITL feature.
+
+### 2.2. Core Data Structures
+- **`WorkflowTemplate`**: The blueprint for a reusable workflow, defining its name, description, and steps.
+- **`WorkflowStep`**: Defines a single action within a workflow, including its type (`prompt`, `agent-task`, `human-in-the-loop`), the template it uses, and how it maps input from previous steps.
+- **`WorkflowRun`**: Represents a live execution instance of a workflow, tracking its status, current step, and the outputs of completed steps.
+
+### 2.3. Architectural Components
+- **`WorkflowControl.tsx`**: The UI for building and launching a workflow.
+- **`WorkflowControlModule.ts`**: The `ControlModule` that registers the UI and fires the start event.
+- **`useWorkflowStore.ts`**: A Zustand store holding the state of the currently executing `WorkflowRun`.
+- **`WorkflowService.ts`**: The stateless orchestrator that listens for events and executes the workflow steps.
+- **`workflow.events.ts`**: Defines the event contracts for the workflow lifecycle.
+
+## 3. Implementation Plan
+
+### Phase 1: Foundation & Data Model Integration
+- **Task**: Define and integrate the core data structures and events.
+- **Files**: `interaction.ts`, `workflow.ts` (new), `events/workflow.events.ts` (new), `modding.ts`.
+- **Status**: ✅ **DONE**
+
+### Phase 2: Workflow Store
+- **Task**: Create the `useWorkflowStore` to manage the state of the active workflow run.
+- **Files**: `store/workflow.store.ts` (new), `services/event-action-coordinator.service.ts`.
+- **Status**: ✅ **DONE**
+
+### Phase 3: Workflow Service (Orchestrator)
+- **Task**: Implement the core workflow execution logic for starting, pausing, resuming, and completing workflows.
+- **Files**: `services/workflow.service.ts` (new), `components/LiteChat/LiteChat.tsx`.
+- **Status**: ✅ **DONE**
+
+### Phase 4: Workflow Builder UI & Module
+- **Task**: Create the user-facing UI for building and launching workflows.
+- **Files**: `controls/modules/WorkflowControlModule.ts` (new), `controls/components/workflow/WorkflowBuilder.tsx` (new), `controls/components/workflow/WorkflowStepCard.tsx` (new), `App.tsx`.
+- **Status**: ✅ **DONE**
+
+### Phase 5: Workflow Execution UI
+- **Task**: Render the running workflow and the HITL controls in the chat canvas.
+- **Files**: `components/LiteChat/canvas/InteractionCard.tsx`, `components/LiteChat/canvas/interaction/WorkflowStatusDisplay.tsx` (new), `components/LiteChat/canvas/interaction/HumanInTheLoopControl.tsx` (new).
+- **Status**: ✅ **DONE**
+
+### Phase 6: Structured Output & Data Passing
+- **Task**: Implement the logic for passing data between steps by dynamically instructing the AI to provide structured JSON output and parsing it.
+- **Files**: `services/workflow.service.ts`.
+- **Status**: ✅ **DONE**
+
+### Phase 7: Future Enhancements
+- Saving, loading, and sharing of `WorkflowTemplate` objects.
+- Conditional logic and branching (`if/else`).
+- Looping over lists of data.
+- Refactoring the `Race-Combine` feature to use the new workflow engine.
+- **Status**: 🔲 **PENDING** 


### PR DESCRIPTION
the prompt :
```
in @RacePromptControl.tsx and @RacePromptControlModule.ts we have the premices of a workflow architecture.

I would like you to very carefully analyze all the cogs of the race modules, including events, stores and the various bits and bobs all around.
I also want you to analyze the reference feature I give you in the same way !
You have to analyze again very carefully once you have all the needed file for your understanding. @llm.dev.txt will help you understand the whole app architecture (think event driven, not stores ! this is very important, if you can do it using the event system you should do it that way, plan accordingly !)

Once you are in full knowledge of the existing feature and how it clicks in the app i want you to **plan** a "workflow" module. I want to be able to 
* write a prompt, select one from the @PromptLibraryControlModule.ts  or an @AgentControlModule.ts tasks
* select the followup prompt template or task, the defined variable will serve to force the structured output of the previous prompt
* add as many steps as i want
* have a "human in the loop" step
* trigger the workflow

It should display as the @RacePromptControlModule.ts does when in combined mode.
As you can see, the race module combine as been jerryrigged a bit, I want the workflow not to be ! we will rebase the race on it once it the workflow feature is more comlpete.

I want you to **PLAN** all that and put that plan in workflow_plan.md.
It has to be thorough as it will serve as a working document for future assistant. Think TODO on steroids ! 
I want it carefully stepped, with detailled analysis, list of files impacted for each step, why, potential pitfalls ! I want it all encompassing and be the ultimate reference for me to build this feature !
```