### PR TITLE
fix: restore code block content when canceling edit

### DIFF
--- a/src/components/LiteChat/common/CodeBlockRenderer.tsx
+++ b/src/components/LiteChat/common/CodeBlockRenderer.tsx
@@ -131,10 +131,10 @@ const CodeBlockRendererComponent: React.FC<CodeBlockRendererProps> = ({
   }, [code]);
 
   useEffect(() => {
-    if (!isFolded) {
+    if (!isFolded && !isEditing) {
       highlightCode();
     }
-  }, [code, lang, isFolded, highlightCode]);
+  }, [code, lang, isFolded, isEditing, highlightCode]);
 
   const toggleFold = () => {
     const unfolding = isFolded;


### PR DESCRIPTION
The highlightCode effect wasn't triggered when exiting edit mode via cancel, causing the code block to appear empty. Added isEditing to the effect dependencies to ensure content is re-rendered when transitioning out of edit mode.
<img width="644" height="120" alt="image" src="https://github.com/user-attachments/assets/c2794d32-2050-434b-a6ec-d2421ef8be31" />
