### PR TITLE
Fix/working docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Build artifacts (except the build directory we want to copy)
-dist/
 coverage/
 
 # Development files
@@ -71,4 +70,4 @@ pnpm-lock.yaml
 dockerfile
 dockerfile.tmp.*
 docker-compose.yml
-.dockerignore 
+.dockerignore

--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,7 @@
 FROM lipanski/docker-static-website:latest
 
 # Copy the built application files
-COPY build/ .
+COPY dist/ .
 
 # Create httpd.conf for SPA routing and any needed configuration
 COPY docker/httpd.conf .

--- a/docs/build-deployment.md
+++ b/docs/build-deployment.md
@@ -446,7 +446,7 @@ LiteChat uses a minimal Docker setup based on [lipanski/docker-static-website](h
 FROM lipanski/docker-static-website:latest
 
 # Copy the built application files
-COPY build/ .
+COPY dist/ .
 
 # Create httpd.conf for SPA routing and any needed configuration
 COPY docker/httpd.conf .
@@ -604,7 +604,7 @@ bin/builder --release v1.0.0 --docker-repo myuser/litechat
 # Manual language-specific build (example for French)
 cat > dockerfile.fr << EOF
 FROM lipanski/docker-static-website:latest
-COPY build/fr/ .
+COPY dist/fr/ .
 COPY docker/httpd.conf .
 EOF
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -106,7 +106,7 @@ bin/builder --release v1.0.0 --docker-repo myuser/litechat
 # Example: Build French version manually
 cat > dockerfile.fr << EOF
 FROM lipanski/docker-static-website:latest
-COPY build/fr/ .
+COPY dist/fr/ .
 COPY docker/httpd.conf .
 EOF
 
@@ -243,7 +243,7 @@ COPY . .
 RUN npm run build
 
 FROM lipanski/docker-static-website:latest
-COPY --from=builder /app/build/ .
+COPY --from=builder /app/dist/ .
 COPY docker/httpd.conf .
 ```
 


### PR DESCRIPTION
Some small fixes were needed for getting docker compose up and running:
- use /dist instead of /build folder
- added missing httpd.conf file

Along the other PR of https://github.com/DimitriGilbert/LiteChat/pull/100 I can confirm that I was able to get LiteChat up and running on my homeserver, and visitable from my laptop using tailscale without any issues! :)